### PR TITLE
fix corrupt nginx configuration

### DIFF
--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -12,8 +12,10 @@ http {
     }
 
     upstream kancolle_servers {
+        least_conn;
+
         server 203.104.209.71;
-        server 125.6.184.15;
+        server 203.104.209.87;
         server 125.6.184.16;
         server 125.6.187.205;
         server 125.6.187.229;
@@ -35,9 +37,11 @@ http {
     }
 
     server {
+        server_name DOMAIN_NAME;
         listen 80;
 
-        server_name DOMAIN_NAME;
+        include       mime.types;
+        default_type  application/octet-stream;
 
         gzip on;
         gzip_types text/plain text/css application/json application/x-shockwave-flash audio/mpeg image/png;
@@ -48,27 +52,38 @@ http {
         gzip_http_version 1.1;
         gzip_min_length 256;
 
-        location / {
-            proxy_pass http://modcolle_servers;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection 'upgrade';
-            proxy_set_header Host $host;
-            proxy_cache_bypass $http_upgrade;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_cache_bypass $http_upgrade;
+
+        # internal redirect to /kcs/*
+        location ~* ^/(Core.swf|PortMain.swf) {
+            rewrite . /kcs$uri last;
+        }
+
+        location /resources/ {
+            rewrite . /kcs$uri last;
+        }
+
+        location /scenes/ {
+            rewrite . /kcs$uri last;
         }
 
         # all kancolle game assets will be redirect to their servers
         location /kcs/ {
             proxy_pass http://kancolle_servers;
+
+            # DONT remove this. It will cause nginx to respond http 503 due to mismatched host with upstream servers
+            proxy_set_header Host $host;
         }
 
-        error_page  404 /404.html;
-
-        # redirect server error pages to the static page /50x.html
-        #
-        error_page   500 502 503 504 /50x.html;
-        location = /50x.html {
-            root   html;
+        location / {
+            proxy_pass http://modcolle_servers;
+            proxy_set_header Host $host;
         }
+
+        error_page 404 /404.html;
+        error_page 500 502 503 504 /50x.html;
     }
 }


### PR DESCRIPTION
* fix asset not found due to files moved to /kcs at kc serv
Core.swf, PortMain.swf, /scences/, /resources/, are moved to /kcs/ folder since Nov. 18 maintenace but mainD2.swf still request these files from root directory in modcolle.
Let nginx perform internal uri rewrite and redirect these files to /kcs/

* fix nginx 503 status in kancolle_servers in nginx conf because there is no $host header
Default http host header is `kancolle_servers` but it should be one of the ip in upstream.
That's why it confuse nginx bacause host header doesn't match with the proxied upstream server hostname.
Took me almost 3 days to find out.

* update new world 2 server ip
server world 2 ip address has been changed to the new ip 125.6.184.15 -> 203.104.209.87

* use "least connection" algorithm on kancolle_servers
because servers ip location of 203.104.x.x and 125.6.x.x are close together based on masked ip address.
so it should redirect to the least busiest servers with the least connection

* include mime.types and use proxy_http 1.1 to all proxy uri
strengthen connection security