### PR TITLE
automatically prefix, minify, and browser sync css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Project gitignore
 src/config/settings.json
 .env
+*.min.*
 
 # Nodejs gitignore template
 # Obtained from https://github.com/github/gitignore/blob/master/Node.gitignore

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,8 +5,12 @@ const postcss = require('gulp-postcss')
 const autoprefixer = require('autoprefixer')
 const cleanCSS = require('gulp-clean-css')
 const rename = require('gulp-rename')
+const bs = require('browser-sync').create()
+const nodemon = require('gulp-nodemon')
 
+const devPort = 8080
 const css = 'src/views/*.css'
+const htmlTemplate = 'src/views/**/*.hbs'
 
 gulp.task('build', ['build:css'])
 
@@ -16,8 +20,30 @@ gulp.task('build:css', () => {
   .pipe(postcss([autoprefixer()]))
   .pipe(cleanCSS())
   .pipe(gulp.dest('src/views/public/css'))
+  .pipe(bs.stream())
 })
 
-gulp.task('watch', () => {
+gulp.task('nodemon', done => {
+  let start = false
+  return nodemon({
+    script: 'bin/www',
+    ignore: ['gulpfile.js', 'node_modules/', 'src/views/'],
+    env: {PORT: devPort}
+  })
+  .on('start', () => {
+    if(!start) {
+      start = true
+      done()
+    }
+  })
+})
+
+gulp.task('browser-sync', ['nodemon'], () => {
+  bs.init({
+    proxy: `localhost:${devPort}`,
+    open: false
+  })
+
   gulp.watch(css, ['build:css'])
+  gulp.watch(htmlTemplate, bs.reload)
 })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const gulp = require('gulp')
+const postcss = require('gulp-postcss')
+const autoprefixer = require('autoprefixer')
+const cleanCSS = require('gulp-clean-css')
+const rename = require('gulp-rename')
+
+const css = 'src/views/*.css'
+
+gulp.task('build', ['build:css'])
+
+gulp.task('build:css', () => {
+  return gulp.src(css)
+  .pipe(rename({suffix: '.min'}))
+  .pipe(postcss([autoprefixer()]))
+  .pipe(cleanCSS())
+  .pipe(gulp.dest('src/views/public/css'))
+})
+
+gulp.task('watch', () => {
+  gulp.watch(css, ['build:css'])
+})

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "eslint": "./node_modules/.bin/eslint"
   },
   "scripts": {
-    "start": "nf start",
-    "dev": "nf run nodemon ./bin/www",
+    "start": "gulp build && nf start",
+    "dev": "gulp build && nf run gulp browser-sync",
     "coverage": "nf run istanbul cover ./node_modules/mocha/bin/_mocha",
     "eslint": "eslint src/**/*.js test/**/*.js bin/**",
     "utest": "nf run mocha",
@@ -45,9 +45,16 @@
   },
   "devDependencies": {
     "app-root-path": "2.0.1",
+    "autoprefixer": "6.7.0",
+    "browser-sync": "2.18.6",
     "cheerio": "0.22.0",
     "coveralls": "2.11.14",
     "eslint": "3.9.1",
+    "gulp": "3.9.1",
+    "gulp-clean-css": "2.3.2",
+    "gulp-nodemon": "2.2.1",
+    "gulp-postcss": "6.3.0",
+    "gulp-rename": "1.2.2",
     "istanbul": "0.4.5",
     "mocha": "3.1.2",
     "nock": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,14 @@
     "eslint": "./node_modules/.bin/eslint"
   },
   "scripts": {
-    "start": "gulp build && nf start",
-    "dev": "gulp build && nf run gulp browser-sync",
+    "build": "gulp build",
+    "prestart": "npm run build",
+    "start": "nf start",
+    "dev": "npm run build && nf run gulp browser-sync",
     "coverage": "nf run istanbul cover ./node_modules/mocha/bin/_mocha",
     "eslint": "eslint src/**/*.js test/**/*.js bin/**",
     "utest": "nf run mocha",
+    "pretest": "npm run build",
     "test": "npm run eslint && npm run utest"
   },
   "dependencies": {

--- a/src/views/style.css
+++ b/src/views/style.css
@@ -1,0 +1,322 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+/* background gitter fix for IE */
+html {
+    overflow: hidden;
+    height: 100%;
+}
+
+body {
+    overflow: auto;
+    height: 100%;
+}
+/* --------- */
+
+body {
+  background-color: #eee;
+  font-family: 'FontAwesome', san-serif;
+  margin: 0;
+}
+
+.clearfix {
+  clear: both;
+}
+
+.container {
+  overflow: auto;
+  padding: 0 4%;
+  background-color: #eee;
+}
+
+header {
+  overflow: auto;
+}
+
+#header-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* Start Banner */
+.banner {
+  position: relative;
+  font-size: 2.0em;
+  text-decoration: none;
+  overflow: hidden;
+}
+.cover {
+  background-attachment: fixed;
+  position: relative;
+  overflow: hidden;
+  height: 100vh;
+}
+.background {
+  position: fixed;
+  z-index: -1;
+}
+.cloud {
+  height: auto;
+  top: 0;
+  left: 0;
+  min-height: 100%;
+  min-width: 1024px;
+  width: 100%;
+}
+.kaga {
+  right: 0%;
+  top: 5%;
+  width: auto;
+  height: 100%;
+  
+  will-change: transform, opacity;
+  transform: translate3d(0px,0px,0px);
+  animation:
+    fade-in .8s ease-out,
+    slide-in 1.2s ease,
+    bounce 3s 1.6s infinite;
+}
+@keyframes slide-in {
+  0% { top: 100%; }
+  70% { top: 0%; }
+  100% { top: 5%; }
+}
+@keyframes fade-in {
+  from { opacity: 0 }
+  to { opacity: 1 }
+}
+@keyframes bounce {
+  50% { transform: translate3d(0px,-20px,0px); }
+}
+.banner-content-wrapper {
+  background: linear-gradient(to right, rgba(54,83,156,1) 0%, rgba(54,84,156,0.5) 65%, rgba(54,83,156,0) 100%);
+  padding: 0 70px 20px 70px;
+  position: absolute;
+  bottom: 0%;
+  height: 100%;
+}
+.logo {
+  padding-bottom: 10px;
+}
+.banner-content {
+  margin-top: 40%;
+  width: 100%;
+  color: #fff;
+  text-align: center;
+  text-shadow: 1px 1px 4px rgba(0,0,0,0.8);
+}
+#launcher {
+  margin-top: 20px;
+  filter: drop-shadow(0px 0px 5px #f2e1f2);
+}
+#launcher:hover {
+  filter: drop-shadow(0px 0px 15px #f2e1f2);
+  cursor: pointer;
+
+  will-change: transform;
+  animation: swing-half .5s, swing 3s .5s infinite;
+}
+@keyframes swing-half {
+  100% { transform: rotate(-10deg); }
+}
+@keyframes swing {
+  0% { transform: rotate(-10deg); }
+  50% { transform: rotate(10deg); }
+  100% { transform: rotate(-10deg); }
+}
+.hr-line {
+  margin-top: 20px;
+  border-bottom: 1px solid white;
+}
+.github {
+  position: absolute;
+  top: 85%;
+  left: 90%;
+  background-color: rgba(0,0,0,0.6);
+  border-radius: 20%;
+  padding: 10px;
+  color: #fff;
+  transition: background-color 0.2s ease;
+}
+.github:hover {
+  background-color: rgba(0,0,0,0.8);
+}
+/* End Banner */
+
+/* Start Feature */
+.one-third {
+  width: 30%;
+  height: 330px;
+  text-align: center;
+  background-color: #fff;
+  border-radius: 40px;
+  box-shadow: 5px 10px 20px 0px rgba(0,0,0,0.75);
+  float: left;
+  padding: 40px 0;
+  margin: 50px 0;
+}
+.one-third:nth-child(2) {
+  margin-left: 5%;
+  margin-right: 5%;
+}
+.icon {
+  font-size: 10em;
+  color: #2C417C;
+}
+.one-third h1 {
+  margin-top: 40px;
+}
+.one-third p {
+  width: 80%;
+  margin: 15px auto;
+  font-size: 1.25em;
+  font-weight: 550;
+}
+.one-third a {
+  text-decoration: none;
+  color: #2C417C;
+  font-weight: 800;
+}
+.one-third a:hover {
+  color: #5573c3;
+}
+/* End Feature */
+
+/* Start Login Modal */
+.modal-dialog {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: rgba(0,0,0,0.8);
+  z-index: 1;
+  opacity:0;
+  pointer-events: none;
+}
+.modal-dialog:target {
+  opacity:1;
+  transition: opacity 400ms ease-in;
+  pointer-events: auto;
+}
+.modal-dialog > div {
+  width: 41%;
+  position: relative;
+  margin: 10% auto;
+  padding: 10px 20px 13px 20px;
+  border-radius: 10px;
+  background: #F0F0F0;
+  background: linear-gradient(#fff, #999);
+}
+.close {
+  background: #606061;
+  color: #FFFFFF;
+  line-height: 25px;
+  position: absolute;
+  right: -12px;
+  text-align: center;
+  top: -10px;
+  width: 24px;
+  text-decoration: none;
+  font-weight: bold;
+  border-radius: 12px;
+  box-shadow: 1px 1px 3px #000;
+}
+.close:hover { background: #00d9ff; }
+
+/* -- Start Tabs -- */
+.modal-dialog input.tabs, .modal-dialog section {
+  display: none;
+}
+.modal-dialog section {
+  border-top: 1px solid #ddd;
+}
+label.tabs {
+  display: inline-block;
+  margin: 0 0 -1px;
+  padding: 15px 25px;
+  font-weight: 600;
+  text-align: center;
+  color: #bbb;
+  border: 1px solid transparent;
+}
+label.tabs:before {
+  font-weight: normal;
+  margin-right: 10px;
+}
+label.tabs:hover {
+  color: #888;
+  cursor: pointer;
+}
+input:checked + label.tabs {
+  color: #555;
+  border: 1px solid #ddd;
+  border-top: 2px solid orange;
+  border-bottom: 1px solid #fff;
+}
+#session:checked ~ #form-session,
+#account:checked ~ #form-account {
+  display: block;
+}
+/* -- End Tabs -- */
+/* -- Start Form -- */
+.modal-dialog form {
+  /*background-color: orange;*/
+  width: 95%;
+  padding: 25px 20px;
+}
+.modal-dialog input,
+.modal-dialog textarea {
+  display: block;
+  font-size: 1.25em;
+  margin: 4px 0 25px 0;
+  border-radius: 10px;
+}
+.modal-dialog span {
+  font-size: 1.5em;
+  font-weight: 600;
+}
+.modal-dialog input {
+  padding: 10px 20px;
+  width: 90%;
+}
+.modal-dialog button[type="submit"] {
+  margin: 0 12%;
+  width: 70%;
+  height: 55px;
+  border-radius: 10px;
+  font-weight: 800;
+  font-size: 1.3em;
+  letter-spacing: 2px;
+  background-color: #2280c3;
+  color: #f5f5f5;
+  transition: background-color 0.5s ease;
+}
+.modal-dialog button[type="submit"]:hover {
+  background-color: #3c9add;
+  cursor: pointer;
+}
+/* -- End Form -- */
+/* End Login Modal*/
+
+/* Start Footer */
+footer.second {
+  width: 100%;
+  background: linear-gradient(#5070AD, #284F94);
+  padding: 15px 0;
+  letter-spacing: 2px;
+  line-height: 25px;
+  border-top: 5px solid hsl(0, 0%, 80%);
+}
+footer.second p, footer.second a {
+  color: white;
+  text-align: center;
+  text-decoration: none;
+}
+footer.second a:hover {
+  color: black;
+}
+/* End Footer */


### PR DESCRIPTION
This PR is useful for development purpose especially front-end development.
 
I moved style.css out of `public` folder and replaced with style.min.css in which to be built by Gulp inside `public/css`.

- any file with name *.min.* (means minified) will be ignored. Usually applied to minified CSS and JS
- Building task `gulp build` will run before `start`, `dev`, and `test` to build front-end assets
