### PR TITLE
gitignore only fonts and minified css/js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # Project gitignore
-public
 src/config/settings.json
 .env.json
+
+# Public assets gitignore
 *.min.*
+fonts
 
 # Nodejs gitignore template
 # Obtained from https://github.com/github/gitignore/blob/master/Node.gitignore


### PR DESCRIPTION
Ignore whole `public` may not be a good idea.
Not all static assets have to be built from gulp.
Like images or other binary files.