### PR TITLE
Run test coverage with nyc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ script:
   - npm run eslint
   - npm run coverage
 
-after_script:
-  - "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+after_success:
+  - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "mocha": "./node_modules/mocha/bin/mocha",
     "eslint": "./node_modules/.bin/eslint"
   },
+  "nyc": {
+    "exclude": ["gulpfile.js"]
+  },
   "scripts": {
     "build": "gulp build && gulp import",
     "prestart": "npm run build",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "bin": {
     "mocha": "./node_modules/mocha/bin/mocha",
-    "istanbul": "./node_modules/.bin/istanbul",
     "eslint": "./node_modules/.bin/eslint"
   },
   "scripts": {
@@ -21,7 +20,8 @@
     "preinstall": "npm prune",
     "start": "node bin/www",
     "dev": "npm run build && gulp browser-sync",
-    "coverage": "npm run pretest && istanbul cover ./node_modules/mocha/bin/_mocha",
+    "coverage": "nyc npm test",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "eslint": "eslint src/**/*.js test/**/*.js bin/**",
     "utest": "mocha",
     "pretest": "npm run build",
@@ -66,10 +66,10 @@
     "gulp-rename": "1.2.2",
     "gulp-uglify": "2.0.1",
     "gulp-util": "3.0.8",
-    "istanbul": "0.4.5",
     "mocha": "3.1.2",
     "nock": "9.0.2",
     "nodemon": "1.11.0",
+    "nyc": "10.1.2",
     "should": "11.1.1",
     "sinon": "1.17.6",
     "slash": "1.0.0",


### PR DESCRIPTION
With nyc[https://www.npmjs.com/package/nyc], we can see more detailed coverage info on the command line.
This pr will replace `istanbul` with `nyc` package.