### PR TITLE
remove 'npm prune' from preinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "scripts": {
     "build": "gulp build && gulp import",
     "prestart": "npm run build",
-    "preinstall": "npm prune",
     "start": "node bin/www",
     "dev": "npm run build && gulp browser-sync",
     "coverage": "npm run pretest && istanbul cover ./node_modules/mocha/bin/_mocha",


### PR DESCRIPTION
Implemented in 8352973307517b680fb85c399464754391a6b912, the intention is to have the same dependencies installed across multiple machines.
When the program require unsaved dependencies in `package.json`, it works on local machine but not others.
Doing so we can maintain package consistencies when commits are pushed to github.

Although having `npm prune` in `preinstall` can remove unused package before installation to prevent the above mentioned case.
The process is time-consuming to local machine and even sometimes causes `travis` installation timeout.
