### PR TITLE
Extends Modcolle's eslint config from eslint-config-modcolle repo

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,59 +1,11 @@
 {
-    "env": {
-        "es6": true,
-        "node": true,
-        "mocha": true
-    },
-    "extends": "eslint:recommended",
-    "parserOptions": {
-        "sourceType": "script"
-    },
-    "rules": {
-        "indent": [
-            "error",
-            2
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "never"
-        ],
-        "brace-style": [
-            "error",
-            "1tbs"
-        ],
-        "curly": [
-            "error",
-            "multi",
-            "consistent"
-        ],
-        "comma-spacing": [
-            "error",
-            {"before": false, "after": true}
-        ],
-        "strict": [
-            "error",
-            "global"
-        ],
-        "arrow-parens": [
-            "error",
-            "as-needed"
-        ],
-        "arrow-spacing": "error",
-        "prefer-arrow-callback": "error",
-        "prefer-spread": "error",
-        "prefer-const": "error",
-        "no-var": "error",
-        "dot-notation": "error",
-        "no-trailing-spaces": "error",
-        "no-tabs": "error",
-        "eol-last": "error"
-    }
+  "env": {
+      "es6": true,
+      "node": true,
+      "mocha": true
+  },
+  "extends": "modcolle",
+  "parserOptions": {
+      "sourceType": "script"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "eslint": "./node_modules/.bin/eslint"
   },
   "nyc": {
-    "exclude": ["gulpfile.js"]
+    "exclude": [
+      "gulpfile.js"
+    ]
   },
   "scripts": {
     "build": "gulp build && gulp import",
@@ -33,6 +35,7 @@
     "async": "2.1.2",
     "body-parser": "1.15.2",
     "dot-env": "0.0.1",
+    "eslint-config-modcolle": "0.1.0",
     "express": "4.14.0",
     "express-handlebars": "3.0.0",
     "fallbackjs": "1.1.8",
@@ -60,6 +63,7 @@
     "cheerio": "0.22.0",
     "coveralls": "2.11.14",
     "eslint": "3.9.1",
+    "eslint-config-modcolle": "0.1.0",
     "gulp": "3.9.1",
     "gulp-babel": "6.1.2",
     "gulp-clean-css": "2.3.2",


### PR DESCRIPTION
Because Modcolle has microservices ([modcolle-port](https://github.com/makemek/modcolle-port)), I would like all project use the same eslint configuration.

This PR will reuse eslint configuration from [modcolle-eslint-config](https://github.com/makemek/modcolle-eslint-config)