### PR TITLE
use node alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
-FROM node:6.9.1
+FROM node:6-alpine
 
-MAINTAINER Apipol Niyomsak
+LABEL maintainer "Apipol Niyomsak"
 
-RUN npm install -g pm2
+ARG PORT
+ENV PORT=${PORT} \
+    DEPLOY_DIR=/var/www/modcolle
 
-RUN mkdir -p /var/www/modcolle
+WORKDIR ${DEPLOY_DIR}
+ADD . ${DEPLOY_DIR}
+RUN npm install --only=production -g pm2 && \
+    npm install && \
+    npm run build
 
-# Define working directory
-WORKDIR /var/www/modcolle
+EXPOSE ${PORT}
 
-ADD . /var/www/modcolle/
-
-VOLUME ["/var/www/modcolle/log"]
-
-RUN npm install && npm run build
-
-# Expose port
-EXPOSE 5000
-
-# Run app
 CMD pm2-docker start process.json --auto-exit

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,20 @@ FROM node:6-alpine
 
 LABEL maintainer "Apipol Niyomsak"
 
-ARG PORT
-ENV PORT=${PORT} \
-    DEPLOY_DIR=/var/www/modcolle
+ENV PORT=5000 \
+    DEPLOY_DIR=/var/www/modcolle \
+    USER=www
 
-WORKDIR ${DEPLOY_DIR}
 ADD . ${DEPLOY_DIR}
+
+RUN adduser -S $USER && \
+    chown -R $USER \
+      $DEPLOY_DIR \
+      /usr/local/lib \
+      /usr/local/bin
+
+USER ${USER}
+WORKDIR ${DEPLOY_DIR}
 RUN npm install --only=production -g pm2 && \
     npm install && \
     npm run build


### PR DESCRIPTION
To reduce image size, [node alpine](https://github.com/nodejs/docker-node/tree/master/6.10/alpine) is a lot smaller than node image.
It reduce Modcolle's image size from around 800 MB to 300 MB.