### PR TITLE
doc: remarks when running in development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,15 @@ pm2 start process.yml
 ```
 
 In development mode with [nodemon](https://npmjs.org/packages/nodemon) and [browser-sync](https://npmjs.org/packages/browser-sync)
+> **In this mode, no environment variables are loaded**.
+You can still set them inside a command line if needed.
 ```
 npm run dev
+
+-----------
+(optional) configure browser-sync using environment variables before running.
+PORT=<port number> # browser-sync app's proxy port; default is 5000
+PORT_DEV=<port number> # browser-sync listeing port; default is 3000
 ```
 
 ## Configuration


### PR DESCRIPTION
There should be remarks when running `npm run dev` indicating
- No environment variables are loaded
- Configuring browser-sync's proxy port and app's port