### PR TITLE
npm,doc: 'npm start' launch app using pm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,18 @@ Please follows steps below to run Modcolle
 3. Copy `/deployment/nginx/nginx.conf` to `\path\to\nginx\conf`. Make sure to backup nginx.conf first before overwrite.
 4. Inside nginx.conf replace `app1` and `DOMAIN_NAME` with `localhost`
 5. Start nginx
-6. Type `npm install pm2 -g` and run `pm2 start process.yml`
+6. Type `npm install pm2 -g` and run `npm start`
 7. Open a browser and type `localhost` in the url
 
 ## Starting the Application
-
-As a single instance
+### Cluster Mode
+This command runs [pm2](https://npmjs.org/packages/pm2) using configuration defined in [process.yml](https://github.com/makemek/Modcolle/blob/master/process.yml).
 ```
 npm start
 ```
 
-In cluster mode using [PM2](https://npmjs.org/packages/pm2)
-```
-pm2 start process.yml
-```
-
-In development mode with [nodemon](https://npmjs.org/packages/nodemon) and [browser-sync](https://npmjs.org/packages/browser-sync)
+### Development Mode
+With [nodemon](https://npmjs.org/packages/nodemon) and [browser-sync](https://npmjs.org/packages/browser-sync)
 > **In this mode, no environment variables are loaded**.
 You can still set them inside a command line if needed.
 ```

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "gulp build && gulp import",
     "prestart": "npm run build",
-    "start": "node bin/www",
+    "start": "pm2 start process.yml",
     "dev": "npm run build && gulp browser-sync",
     "coverage": "nyc npm test",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",


### PR DESCRIPTION
# Npm Scripts
The original `npm start` doesn't load environment variables into the application.
Even though you can launch the app with `node bin/www`, you have to set environment manually inside the command line.
And there are lots of them.

`pm2` is more convinient because environment varaibles are defined in `process.yml`, and it can also do cluster mode which is handy in production.
Let's put the launch script inside `npm start` as well to ease remembering pm2's command.

# Update to README.md
Indicates launching mode to be more prominent.
Easy-to-see header with remarks in `npm start`