### PR TITLE
src,dep: prune npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,9 @@
     "test": "npm run eslint && npm run utest"
   },
   "dependencies": {
-    "async": "2.3.0",
     "body-parser": "1.17.1",
-    "eslint-config-modcolle": "0.1.1",
     "express": "4.15.2",
     "express-handlebars": "3.0.0",
-    "fallbackjs": "1.1.8",
-    "font-awesome": "4.7.0",
     "inherit": "2.2.6",
     "morgan": "1.8.1",
     "passport": "0.3.2",
@@ -54,6 +50,7 @@
   },
   "devDependencies": {
     "app-root-path": "2.0.1",
+    "async": "2.3.0",
     "autoprefixer": "6.7.7",
     "babel": "6.23.0",
     "babel-preset-env": "1.4.0",
@@ -63,6 +60,8 @@
     "coveralls": "2.13.0",
     "eslint": "3.19.0",
     "eslint-config-modcolle": "0.1.1",
+    "fallbackjs": "1.1.8",
+    "font-awesome": "4.7.0",
     "gulp": "3.9.1",
     "gulp-babel": "6.1.2",
     "gulp-clean-css": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "passport-local": "1.0.0",
     "request": "2.81.0",
     "request-promise": "4.2.0",
-    "sprintf-js": "1.0.3",
     "tough-cookie": "2.3.2",
     "url-join": "2.0.1",
     "url-parse": "1.1.8",

--- a/src/dmm/osapi.js
+++ b/src/dmm/osapi.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const sprintf = require('sprintf-js').sprintf
 const rp = require('request-promise')
 const log = require('../logger')('service:dmm')
 const errors = require('../errors')
@@ -105,7 +104,7 @@ function getGadgetInfo(htmlString) {
   else
     gadgetInfo = gadgetInfo[0]
 
-  log.debug(sprintf('remove prefix "%s"', varName))
+  log.debug(`remove prefix "${varName}"`)
   gadgetInfo = gadgetInfo.replace(varName, '')
   log.debug(gadgetInfo)
 
@@ -116,7 +115,7 @@ function getGadgetInfo(htmlString) {
   log.debug('put double quotes around the variable')
   varList.forEach(property => {
     property = property.trim()
-    gadgetInfo = gadgetInfo.replace(property, sprintf('"%s"', property))
+    gadgetInfo = gadgetInfo.replace(property, `"${property}"`)
   })
   log.debug(gadgetInfo)
 

--- a/src/kancolle/game.js
+++ b/src/kancolle/game.js
@@ -3,7 +3,6 @@
 const KANCOLLE_MASTER_SERVER = process.env.KANCOLLE_SERVER_MASTER
 const rp = require('request-promise')
 const log = require('../logger')('service:kancolle')
-const sprintf = require('sprintf-js').sprintf
 
 const Kancolle = {
 
@@ -17,8 +16,7 @@ const Kancolle = {
     .then(jsCode => {
       log.info('extract Kancolle server IP addresses, URL info, and maintenance info')
       log.verbose('append js code to output variable value')
-      const var2export = sprintf('JSON.stringify({%s, %s, %s})',
-        'ConstServerInfo', 'ConstURLInfo', 'MaintenanceInfo')
+      const var2export = 'JSON.stringify({ConstServerInfo, ConstURLInfo, MaintenanceInfo})'
       jsCode += ';' + var2export
 
       log.verbose(`emulate javascripts assuming that code from ${url} is trusted`)

--- a/test/unit/mock/dmm/auth.js
+++ b/test/unit/mock/dmm/auth.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const nock = require('nock')
-const sprintf = require('sprintf-js').sprintf
 
 const HOST = 'https://www.dmm.com'
 const TOKEN = {
@@ -25,9 +24,9 @@ nock(HOST)
 .persist()
 .get('/my/-/login/=/path=Sg__/')
 .reply(200, () => {
-  const htmlForm = sprintf('<input type="hidden" name="token" value="%s" id="id_token">', TOKEN.form)
-  const ajaxDmmToken = sprintf('xhr.setRequestHeader("DMM_TOKEN", "%s");', TOKEN.dmm)
-  const ajaxDataToken = sprintf('"token": "%s"', TOKEN.data)
+  const htmlForm = `<input type="hidden" name="token" value="${TOKEN.form}" id="id_token">`
+  const ajaxDmmToken = `xhr.setRequestHeader("DMM_TOKEN", "${TOKEN.dmm}");`
+  const ajaxDataToken = `"token": "${TOKEN.data}"`
 
   return htmlForm + ajaxDmmToken + ajaxDataToken
 })

--- a/test/unit/spec/kancolle-game.js
+++ b/test/unit/spec/kancolle-game.js
@@ -4,7 +4,6 @@ const Kancolle = require(global.SRC_ROOT + '/kancolle/game')
 const rp = require('request-promise')
 const sinon = require('sinon')
 const async = require('async')
-const sprintf = require('sprintf-js').sprintf
 const apiTerminal = require('../mock/kancolle/api-terminal')
 const KancolleChildServers = require(global.SRC_ROOT + '/kancolle/server')
 const should = require('should')
@@ -15,21 +14,8 @@ describe('Kancolle game', () => {
 
   describe('Maintenance test', () => {
 
-    let code
-    beforeEach(() => {
-      code =
-      `
-      var ConstServerInfo = {servFoo:"servBar"}, ConstURLInfo = {urlFoo:"urlBar"}
-      var MaintenanceInfo = {}
-      MaintenanceInfo.IsDoing       = %d
-      MaintenanceInfo.IsEmergency   = %d
-      MaintenanceInfo.StartDateTime = Date.parse("2016/07/15 11:00:00")
-      MaintenanceInfo.EndDateTime   = Date.parse("2016/07/15 17:50:00")
-      `
-    })
-
     it('is NOT on maintenance', done => {
-      const sourceText = sprintf(code, 0, 0)
+      const sourceText = createFakeMaintenanceScript(0, 0)
       const httpRequest = sinon.stub(rp, 'get')
       .returns(Promise.resolve(sourceText))
 
@@ -46,8 +32,8 @@ describe('Kancolle game', () => {
     {doing: 0, emergency: 1},
     {doing: 1, emergency: 0},
     {doing: 1, emergency: 1}], mode => {
-      it(sprintf('is on maintenance (doing = %d, emergency = %d)', mode.doing, mode.emergency), done => {
-        const sourceText = sprintf(code, mode.doing, mode.emergency)
+      it(`is on maintenance (doing = ${mode.doing}, emergency = ${mode.emergency})`, done => {
+        const sourceText = createFakeMaintenanceScript(mode.doing, mode.emergency)
         const httpRequest = sinon.stub(rp, 'get')
         .returns(Promise.resolve(sourceText))
 
@@ -109,4 +95,17 @@ describe('Kancolle game', () => {
       })
     })
   })
+
+  function createFakeMaintenanceScript(isDoing, isEmergency) {
+    const code =
+    `
+    var ConstServerInfo = {servFoo:"servBar"}, ConstURLInfo = {urlFoo:"urlBar"}
+    var MaintenanceInfo = {}
+    MaintenanceInfo.IsDoing       = ${isDoing}
+    MaintenanceInfo.IsEmergency   = ${isEmergency}
+    MaintenanceInfo.StartDateTime = Date.parse("2016/07/15 11:00:00")
+    MaintenanceInfo.EndDateTime   = Date.parse("2016/07/15 17:50:00")
+    `
+    return code
+  }
 })


### PR DESCRIPTION
There are some npm package that are used only in development.
These packages below should be installed as `devDependencies`.

* async
* eslint-config-modcolle
* fallbackjs
* font-awesome

Removed `sprintf-js` package.
We can use string template literal available in Node V6.