### PR TITLE
build: 'gulp build' and 'gulp import' as default task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,6 +27,8 @@ const source = require('vinyl-source-stream')
 const browserify = require('browserify')
 const buffer = require('vinyl-buffer')
 
+gulp.task('default', ['build', 'import'])
+
 gulp.task('build', ['build:css', 'build:js'])
 
 gulp.task('build:css', () => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "scripts": {
-    "build": "gulp build && gulp import",
+    "build": "gulp",
     "prestart": "npm run build",
     "start": "pm2 start process.yml",
     "dev": "npm run build && gulp browser-sync",


### PR DESCRIPTION
Chaining `gulp build` and `gulp import` as default task.
Run `gulp` will run these two tasks.