### PR TITLE
build: fix pm2-docker not found config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN npm install --only=production -g pm2 && \
 
 EXPOSE ${PORT}
 
-CMD pm2-docker start process.json --auto-exit
+CMD pm2-docker start process.yml --auto-exit


### PR DESCRIPTION
Fix pm2's config file not found.
Likely due to #29 