### PR TITLE
build: start process.yml using production environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN npm install --only=production -g pm2 && \
 
 EXPOSE ${PORT}
 
-CMD pm2-docker start process.yml --auto-exit
+CMD pm2-docker start process.yml --env production --auto-exit


### PR DESCRIPTION
By adding `--env production` after `pm2-docker`, pm2 will load `env_production` in process.yml.
Inside the file, `NODE_ENV=production` will tell `express` not to display stacktrace back to the client in case of error occurred.