### PR TITLE
build: reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
 node_modules/*
+.git
+.nyc_output
+coverage
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ RUN adduser -S $USER && \
 USER ${USER}
 WORKDIR ${DEPLOY_DIR}
 RUN npm install --only=production -g pm2 && \
-    npm install && \
-    npm run build
+    npm install --only=development && \
+    npm run build && \
+    rm -rf node_modules && \
+    npm install --only=production
 
 EXPOSE ${PORT}
 


### PR DESCRIPTION
smaller image size from 299 MB to 199 MB by installing only production dependencies and dismiss development dependencies.