### PR TITLE
src: no need to log http request

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "body-parser": "1.17.1",
     "express": "4.15.2",
     "express-handlebars": "3.0.0",
-    "morgan": "1.8.1",
     "passport": "0.3.2",
     "passport-local": "1.0.0",
     "pino": "4.4.0",

--- a/src/modcolle.js
+++ b/src/modcolle.js
@@ -6,7 +6,6 @@ const expressHandlebars = require('express-handlebars')
 const passport = require('passport')
 const LocalStrategy = require('passport-local').Strategy
 const loginStrategy = require('./login-strategy')
-const morgan = require('morgan')
 const app = express()
 const log = require('./logger')('app:router')
 const router = require('./routing/')
@@ -44,14 +43,6 @@ function setupMiddleware() {
   passport.use('dmm-session', new LocalStrategy({
     usernameField: 'dmm_session', passwordField: 'dmm_session'},
   loginStrategy.dmmSession))
-
-  log.debug('configure stream log messages from morgan')
-  const writeStream = {
-    write(message){
-      log.info(message)
-    }
-  }
-  app.use(morgan('combined', {stream: writeStream}))
 }
 
 function setupTemplateEngine() {


### PR DESCRIPTION
# No need to log http request
I think load balancer like Nginx should do the logging instead.
Less logging overhead.