### PR TITLE
config: remove redundant LOGGER_ENABLE and fix LOGGER_PRETTY

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ PORT_DEV=<port number> # browser-sync listeing port; default is 3000
 At `env` section in `process.yml` are environment variables that will override `.env.json` for running in production environment.
 
 ### Environment Variables
-- LOGGER_ENABLE: if `true` enables log, `false` disables log
 - LOGGER_LEVEL: select a [logging level](https://github.com/pinojs/pino/blob/master/docs/API.md#level)
 - LOGGER_PRETTY: pretty print log (should be set to `false` in production)
 - PORT: application port

--- a/process.yml
+++ b/process.yml
@@ -10,7 +10,6 @@ apps:
      pid_file: ./log/modcolle.pid
 
      env:
-      LOGGER_ENABLE: true
       LOGGER_PRETTY: true
       LOGGER_LEVEL: info
       PORT: 5000

--- a/src/logger.js
+++ b/src/logger.js
@@ -11,9 +11,9 @@ const loggers = {}
 labels.forEach(label => {
   loggers[label] = pino({
     name: label,
-    enabled: LOGGER_ENABLE,
+    enabled: LOGGER_ENABLE === 'true',
     level: LOGGER_LEVEL,
-    prettyPrint: LOGGER_PRETTY
+    prettyPrint: LOGGER_PRETTY === 'true'
   })
 })
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -11,7 +11,6 @@ const loggers = {}
 labels.forEach(label => {
   loggers[label] = pino({
     name: label,
-    enabled: LOGGER_ENABLE === 'true',
     level: LOGGER_LEVEL,
     prettyPrint: LOGGER_PRETTY === 'true'
   })


### PR DESCRIPTION
Fix `LOGGER_PRETTY` always be `true` regardless of what value passed in.
Because it expects boolean, but receive a string.

`LOGGER_ENABLE` option is redundant. `LOGGER_LEVEL=silent` can do the same thing.