### PR TITLE
config: use default pm2 log dir

### DIFF
--- a/process.yml
+++ b/process.yml
@@ -5,9 +5,6 @@ apps:
      instances: 0
      merge_logs: true
      exec_mode: cluster_mode
-     error_file: ./log/error.log
-     out_file: ./log/out.log
-     pid_file: ./log/modcolle.pid
 
      env:
       LOGGER_PRETTY: true


### PR DESCRIPTION
By default all pm2 logs that are not location specific will be in ~/.pm2.
Convenient for log rotation since all pm2 apps will save log to the same place 