### PR TITLE
doc: start the application in production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ Please follows steps below to run Modcolle
 
 ## Starting the Application
 ### Cluster Mode
-This command runs [pm2](https://npmjs.org/packages/pm2) using configuration defined in [process.yml](https://github.com/makemek/Modcolle/blob/master/process.yml).
+This command runs [pm2](https://npmjs.org/packages/pm2) using configuration defined in `env` of [process.yml](https://github.com/makemek/Modcolle/blob/master/process.yml).
 ```
 npm start
+```
+You can also start the application in production mode by passing `--env production` to pm2.
+```
+npm start -- --env production
 ```
 
 ### Development Mode


### PR DESCRIPTION
Add more info on starting the application in production mode.
In `process.yml`, there is a `env_production` that pm2 can load them if it receives `--env proudction`  as an argument.
I indicate in the `README.md` that Modcolle can be start by passing argument `--env production` to `npm start` which passes to pm2.