### PR TITLE
src: bump version to v1.0.0 for master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modcolle",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "main": "index.js",
   "author": "MakeMEK",
   "license": "Apache-2.0",


### PR DESCRIPTION
We now have v0.x which owns Modcolle v0.x versioning.
In the master, the version should be bumped to v1